### PR TITLE
Added branch because of small differences in code due to python vs p3

### DIFF
--- a/src/nausbot/scripts/main.py
+++ b/src/nausbot/scripts/main.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 Ship simulator / software-in-the-loop-system that listens to actuation and outputs simulated ship response.


### PR DESCRIPTION
This shebang line indeed allows starting through commandline without specifying python interpreter with me. 
After setting the file as executable
```
cd <repo>/src/nausbot/scripts
chmod +x main.py
```

This now allows running without specifying interpreter:
```
./main.py RAS_TN_OR
```